### PR TITLE
Turn into a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM ruby:2.6.1-slim-stretch
+
+MAINTAINER {{name}} <{{email}}>
+
+ENV WORKDIR /app/
+ENV PORT 3000
+ENV RACK_ENV production
+
+WORKDIR $WORKDIR
+
+COPY . .
+
+RUN bundle install
+
+EXPOSE 3000
+
+CMD ["bundle", "exec", "puma", "-t 1:1", "-p $PORT", "-e $RACK_ENV}


### PR DESCRIPTION
We'll want to replace the name and email parts. I also think the redis connection should be wrapped in `connection_pool` and given a ENV value for pool size. In addition I think it would be advisable to provide values for the puma cluster from the ENV.